### PR TITLE
fix child_handler so as to not strand zombie (defunct) children

### DIFF
--- a/adhocify.c
+++ b/adhocify.c
@@ -709,7 +709,7 @@ void child_handler(int signum, siginfo_t *info, void *context)
 	while (1) {
 		int status;
 		pid_t p = waitpid(-1, &status, WNOHANG);
-		if(p == 0) // No more children to reap
+		if(p == 0 || (p == -1 && errno == ECHILD)) // No more children to reap
 		{
 			return; // exits infinite while loop and child_handler() function
 		}


### PR DESCRIPTION
The adhocify code has a small bug in which it makes a wrong assumption about a 1-to-1 mapping between children exiting and SIGCHLD being sent. As a result, it strands some children when inotify events occur in rapid succession. This PR fixes that issue.

